### PR TITLE
Silence web piano if input is coming from MIDI

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -135,21 +135,17 @@ function onMIDIMessage(message) {
 	switch(type){
 		case 144: // noteOn message
 			if (velocity > 0) {
-				MIDI.noteOn(0, note, velocity, 0);
 				piano.toggleKey(note, true);
 				beatVisualizer.triggerNearestNodeOnChannel(note, currentNumericBeat + percentAccumulator);
 			} else {
-				MIDI.noteOff(0, note, 0);
 				piano.toggleKey(note, false);
 			}
 			break;
 		case 128: // noteOff message
-			MIDI.noteOff(0, note, 0);
 			piano.toggleKey(note, false);
-			// noteOff(note, velocity);
 			break;
 	}
-if (channel != 8 && channel != 14) {
+	if (channel != 8 && channel != 14) {
 		console.log('data', data, 'cmd', cmd, 'channel', channel);
 	}
 	// logger(keyData, 'key data', data);


### PR DESCRIPTION
I found it really annoying that when I used my MIDI keyboard, I'd have to turn it's sound off and use the sound from the computer (or just have both on, but that felt weird).

I thought about making this into an option, but it seemed like there wasn't much of a use case for turning off the web piano when you don't have a midi keyboard, and also not much of a use case for leaving it on if you do have a midi keyboard.

What do you think?